### PR TITLE
Fix legacy HHVM build by downgrading Composer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,5 +40,6 @@ jobs:
       - uses: azjezz/setup-hhvm@v1
         with:
           version: lts-3.30
+      - run: composer self-update --2.2 # downgrade Composer for HHVM
       - run: hhvm $(which composer) install
-      - run: hhvm vendor/bin/phpunit
+      - run: hhvm vendor/phpunit/phpunit/phpunit

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # clue/reactphp-connection-manager-extra
 
-[![CI status](https://github.com/clue/reactphp-connection-manager-extra/workflows/CI/badge.svg)](https://github.com/clue/reactphp-connection-manager-extra/actions)
+[![CI status](https://github.com/clue/reactphp-connection-manager-extra/actions/workflows/ci.yml/badge.svg)](https://github.com/clue/reactphp-connection-manager-extra/actions)
 [![installs on Packagist](https://img.shields.io/packagist/dt/clue/connection-manager-extra?color=blue&label=installs%20on%20Packagist)](https://packagist.org/packages/clue/connection-manager-extra)
 
 This project provides _extra_ (in terms of "additional", "extraordinary", "special" and "unusual") decorators,


### PR DESCRIPTION
Builds on top of the work done by @clue and the discussion inside reactphp/socket#289.

I also updated the path for the CI badge.