### PR TITLE
Support PHP 8.1 and minor clean up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.1
           - 8.0
           - 7.4
           - 7.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   PHPUnit:
-    runs-on: ubuntu-latest
+    name: PHPUnit (PHP ${{ matrix.php }})
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         php:
@@ -23,10 +24,10 @@ jobs:
           - 5.3
     steps:
       - uses: actions/checkout@v2
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          coverage: xdebug
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
         if: ${{ matrix.php >= 7.3 }}
@@ -36,6 +37,7 @@ jobs:
   PHPUnit-hhvm:
     name: PHPUnit (HHVM)
     runs-on: ubuntu-18.04
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - uses: azjezz/setup-hhvm@v1

--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ $connector->connect('www.google.com:80')->then(function ($stream) {
 Because everything uses the same simple API, the resulting `Connector` classes can be easily interchanged
 and be used in places that expect the normal `ConnectorInterface`. This can be used to stack them into each other,
 like using [timeouts](#timeout) for TCP connections, [delaying](#delay) SSL/TLS connections,
-[retrying](#repeat) failed connection attemps, [randomly](#random) picking a `Connector` or
+[retrying](#repeat) failed connection attempts, [randomly](#random) picking a `Connector` or
 any combination thereof.
 
 ## Usage
 
-This section lists all this libraries' features along with some examples.
+This section lists all features of this library along with some examples.
 The examples assume you've [installed](#install) this library and
 already [set up a `Socket/Connector` instance `$connector`](https://github.com/reactphp/socket#connector).
 
@@ -148,7 +148,7 @@ simplify exchanging the actual `ConnectionManager` during runtime (`->setConnect
 
 ### Consecutive
 
-The `ConnectionManagerConsecutive($connectors)` establishs connections by trying to connect through
+The `ConnectionManagerConsecutive($connectors)` establishes connections by trying to connect through
 any of the given `ConnectionManager`s in consecutive order until the first one succeeds.
 
 ```php
@@ -186,7 +186,7 @@ $concurrent = new ConnectionManagerConcurrent(array(
 
 The `ConnectionManagerSelective($connectors)` manages a list of `Connector`s and
 forwards each connection through the first matching one.
-This can be used to implement networking access control lists (ACLs) or firewill
+This can be used to implement networking access control lists (ACLs) or firewall
 rules like a blacklist or whitelist.
 
 This allows fine-grained control on how to handle outgoing connections, like
@@ -247,7 +247,7 @@ Passing anything else will result in an `InvalidArgumentException`.
 
 ## Install
 
-The recommended way to install this library is [through Composer](https://getcomposer.org).
+The recommended way to install this library is [through Composer](https://getcomposer.org/).
 [New to Composer?](https://getcomposer.org/doc/00-intro.md)
 
 This project follows [SemVer](https://semver.org/).
@@ -262,12 +262,12 @@ See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 This project aims to run on any platform and thus does not require any PHP
 extensions and supports running on legacy PHP 5.3 through current PHP 8+ and
 HHVM.
-It's *highly recommended to use PHP 7+* for this project.
+It's *highly recommended to use the latest supported PHP version* for this project.
 
 ## Tests
 
 To run the test suite, you first need to clone this repo and then install all
-dependencies [through Composer](https://getcomposer.org):
+dependencies [through Composer](https://getcomposer.org/):
 
 ```bash
 $ composer install
@@ -276,7 +276,7 @@ $ composer install
 To run the test suite, go to the project root and run:
 
 ```bash
-$ php vendor/bin/phpunit
+$ vendor/bin/phpunit
 ```
 
 ## License

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,8 +4,9 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
+         cacheResult="false"
          colors="true"
-         cacheResult="false">
+         convertDeprecationsToExceptions="true">
     <testsuites>
         <testsuite name="Connection-Manager-Extra Test Suite">
             <directory>./tests/</directory>
@@ -16,4 +17,7 @@
             <directory>./src/</directory>
         </include>
     </coverage>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
 </phpunit>


### PR DESCRIPTION
This changeset adds support for PHP 8.1 and adds `convertDeprecationsToExceptions="true"` to the `phpunit.xml` configuration to make sure we'll see future deprecation notices.

Builds on top of #30.