### PR TITLE
Improve PHP 8.4+ support by avoiding implicitly nullable types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.4
           - 8.3
           - 8.2
           - 8.1

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     "require": {
         "php": ">=5.3",
         "react/event-loop": "^1.2",
-        "react/promise": "^3 || ^2.1 || ^1.2.1",
-        "react/promise-timer": "^1.9",
-        "react/socket": "^1.12"
+        "react/promise": "^3.2 || ^2.1 || ^1.2.1",
+        "react/promise-timer": "^1.11",
+        "react/socket": "^1.16"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"

--- a/src/ConnectionManagerDelay.php
+++ b/src/ConnectionManagerDelay.php
@@ -23,8 +23,12 @@ class ConnectionManagerDelay implements ConnectorInterface
      * @param float $delay
      * @param ?LoopInterface $loop
      */
-    public function __construct(ConnectorInterface $connectionManager, $delay, LoopInterface $loop = null)
+    public function __construct(ConnectorInterface $connectionManager, $delay, $loop = null)
     {
+        if ($loop !== null && !$loop instanceof LoopInterface) { // manual type check to support legacy PHP < 7.1
+            throw new \InvalidArgumentException('Argument #3 ($loop) expected null|React\EventLoop\LoopInterface');
+        }
+
         $this->connectionManager = $connectionManager;
         $this->delay = $delay;
         $this->loop = $loop ?: Loop::get();

--- a/src/ConnectionManagerTimeout.php
+++ b/src/ConnectionManagerTimeout.php
@@ -23,8 +23,12 @@ class ConnectionManagerTimeout implements ConnectorInterface
      * @param float $timeout
      * @param ?LoopInterface $loop
      */
-    public function __construct(ConnectorInterface $connectionManager, $timeout, LoopInterface $loop = null)
+    public function __construct(ConnectorInterface $connectionManager, $timeout, $loop = null)
     {
+        if ($loop !== null && !$loop instanceof LoopInterface) { // manual type check to support legacy PHP < 7.1
+            throw new \InvalidArgumentException('Argument #3 ($loop) expected null|React\EventLoop\LoopInterface');
+        }
+
         $this->connectionManager = $connectionManager;
         $this->timeout = $timeout;
         $this->loop = $loop ?: Loop::get();

--- a/tests/ConnectionManagerDelayTest.php
+++ b/tests/ConnectionManagerDelayTest.php
@@ -21,12 +21,20 @@ class ConnectionManagerDelayTest extends TestCase
     {
         $unused = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $cm = new ConnectionManagerDelay($unused, 0);
-        
+
         $ref = new \ReflectionProperty($cm, 'loop');
         $ref->setAccessible(true);
         $loop = $ref->getValue($cm);
-        
+
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
+    public function testContructorThrowsExceptionForInvalidLoop()
+    {
+        $unused = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+
+        $this->setExpectedException('InvalidArgumentException', 'Argument #3 ($loop) expected null|React\EventLoop\LoopInterface');
+        new ConnectionManagerDelay($unused, 0, 'loop');
     }
 
     public function testDelayTenth()

--- a/tests/ConnectionManagerTimeoutTest.php
+++ b/tests/ConnectionManagerTimeoutTest.php
@@ -31,6 +31,14 @@ class ConnectionManagerTimeoutTest extends TestCase
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
     }
 
+    public function testContructorThrowsExceptionForInvalidLoop()
+    {
+        $unused = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+
+        $this->setExpectedException('InvalidArgumentException', 'Argument #3 ($loop) expected null|React\EventLoop\LoopInterface');
+        new ConnectionManagerTimeout($unused, 0, 'loop');
+    }
+
     public function testTimeoutOkay()
     {
         $will = $this->createConnectionManagerMock(true);


### PR DESCRIPTION
This changeset improves PHP 8.4+ support by avoiding implicitly nullable types as discussed in https://github.com/reactphp/promise/pull/260. The same idea applies, but v1 requires manual type checks to support legacy PHP versions as the nullable type syntax requires PHP 7.1+ otherwise.

Builds on top of #40, #33, https://github.com/reactphp/promise/pull/260, https://github.com/reactphp/promise-timer/pull/70 and https://github.com/reactphp/socket/pull/318