### PR TITLE
Run tests on PHP 8.5 and update test environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.5
           - 8.4
           - 8.3
           - 8.2
@@ -26,7 +27,7 @@ jobs:
           - 5.4
           - 5.3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -39,7 +40,7 @@ jobs:
     runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: cp "$(which composer)" composer.phar && ./composer.phar self-update --2.2 # downgrade Composer for HHVM
       - name: Run hhvm composer.phar require react/promise:^2 # downgrade Promise for HHVM
         uses: docker://hhvm/hhvm:3.30-lts-latest

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     ],
     "require": {
         "php": ">=5.3",
-        "react/event-loop": "^1.2",
-        "react/promise": "^3.2 || ^2.1 || ^1.2.1",
+        "react/event-loop": "^1.6",
+        "react/promise": "^3.3 || ^2.1 || ^1.2.1",
         "react/promise-timer": "^1.11",
-        "react/socket": "^1.16"
+        "react/socket": "^1.17"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6 || ^8.5 || ^5.7 || ^4.8.36"

--- a/tests/ConnectionManagerDelayTest.php
+++ b/tests/ConnectionManagerDelayTest.php
@@ -23,7 +23,9 @@ class ConnectionManagerDelayTest extends TestCase
         $cm = new ConnectionManagerDelay($unused, 0);
 
         $ref = new \ReflectionProperty($cm, 'loop');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($cm);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);

--- a/tests/ConnectionManagerTimeoutTest.php
+++ b/tests/ConnectionManagerTimeoutTest.php
@@ -25,7 +25,9 @@ class ConnectionManagerTimeoutTest extends TestCase
         $cm = new ConnectionManagerTimeout($unused, 0);
 
         $ref = new \ReflectionProperty($cm, 'loop');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($cm);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);


### PR DESCRIPTION
Builds on top of #41, #42, https://github.com/reactphp/socket/pull/325, https://github.com/reactphp/promise/pull/264, https://github.com/reactphp/event-loop/pull/282, and https://github.com/clue/framework-x/pull/297